### PR TITLE
IN-1747 use service user auth

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -155,17 +155,9 @@ func (p *M3terProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
-	client, err := m3ter.NewClientWithServiceUserAuth(
-		ctx,
+	client := m3ter.NewClientWithServiceUserAuth(
 		opts...,
 	)
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating m3ter client",
-			err.Error(),
-		)
-	}
 
 	resp.DataSourceData = client
 	resp.ResourceData = client


### PR DESCRIPTION
Patch the SDK to use service user auth. 
This needs to be merged after `next` is merged into `main`. 