### PR TITLE
Revert "IN-1755 version attribute fix"

### DIFF
--- a/internal/apijson/encoder.go
+++ b/internal/apijson/encoder.go
@@ -513,7 +513,7 @@ func (e *encoder) newStructTypeEncoder(t reflect.Type) encoderFunc {
 				continue
 			}
 			// Computed fields come from the server
-			if ptag.computed && ptag.name != "version" {
+			if ptag.computed {
 				continue
 			}
 

--- a/internal/services/account/resource.go
+++ b/internal/services/account/resource.go
@@ -113,7 +113,6 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.AccountUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/account_plan/resource.go
+++ b/internal/services/account_plan/resource.go
@@ -113,7 +113,6 @@ func (r *AccountPlanResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.AccountPlanUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/aggregation/resource.go
+++ b/internal/services/aggregation/resource.go
@@ -113,7 +113,6 @@ func (r *AggregationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.AggregationUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/balance/resource.go
+++ b/internal/services/balance/resource.go
@@ -113,7 +113,6 @@ func (r *BalanceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.BalanceUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/bill_config/resource.go
+++ b/internal/services/bill_config/resource.go
@@ -113,7 +113,6 @@ func (r *BillConfigResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.BillConfigUpdateParams{}
 
 	if !data.ID.IsNull() {

--- a/internal/services/commitment/resource.go
+++ b/internal/services/commitment/resource.go
@@ -113,7 +113,6 @@ func (r *CommitmentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.CommitmentUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/compound_aggregation/resource.go
+++ b/internal/services/compound_aggregation/resource.go
@@ -113,7 +113,6 @@ func (r *CompoundAggregationResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.CompoundAggregationUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/contract/resource.go
+++ b/internal/services/contract/resource.go
@@ -113,7 +113,6 @@ func (r *ContractResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.ContractUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/counter/resource.go
+++ b/internal/services/counter/resource.go
@@ -113,7 +113,6 @@ func (r *CounterResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.CounterUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/counter_adjustment/resource.go
+++ b/internal/services/counter_adjustment/resource.go
@@ -113,7 +113,6 @@ func (r *CounterAdjustmentResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.CounterAdjustmentUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/counter_pricing/resource.go
+++ b/internal/services/counter_pricing/resource.go
@@ -113,7 +113,6 @@ func (r *CounterPricingResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.CounterPricingUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/credit_reason/resource.go
+++ b/internal/services/credit_reason/resource.go
@@ -113,7 +113,6 @@ func (r *CreditReasonResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.CreditReasonUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/currency/resource.go
+++ b/internal/services/currency/resource.go
@@ -113,7 +113,6 @@ func (r *CurrencyResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.CurrencyUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/debit_reason/resource.go
+++ b/internal/services/debit_reason/resource.go
@@ -113,7 +113,6 @@ func (r *DebitReasonResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.DebitReasonUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/external_mapping/resource.go
+++ b/internal/services/external_mapping/resource.go
@@ -113,7 +113,6 @@ func (r *ExternalMappingResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.ExternalMappingUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/integration_configuration/resource.go
+++ b/internal/services/integration_configuration/resource.go
@@ -113,7 +113,6 @@ func (r *IntegrationConfigurationResource) Update(ctx context.Context, req resou
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.IntegrationConfigurationUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/meter/resource.go
+++ b/internal/services/meter/resource.go
@@ -113,7 +113,6 @@ func (r *MeterResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.MeterUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/notification_configuration/resource.go
+++ b/internal/services/notification_configuration/resource.go
@@ -113,7 +113,6 @@ func (r *NotificationConfigurationResource) Update(ctx context.Context, req reso
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.NotificationConfigurationUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/permission_policy/resource.go
+++ b/internal/services/permission_policy/resource.go
@@ -113,7 +113,6 @@ func (r *PermissionPolicyResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.PermissionPolicyUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/plan/resource.go
+++ b/internal/services/plan/resource.go
@@ -113,7 +113,6 @@ func (r *PlanResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.PlanUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/plan_group/resource.go
+++ b/internal/services/plan_group/resource.go
@@ -113,7 +113,6 @@ func (r *PlanGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.PlanGroupUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/plan_group_link/resource.go
+++ b/internal/services/plan_group_link/resource.go
@@ -113,7 +113,6 @@ func (r *PlanGroupLinkResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.PlanGroupLinkUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/plan_template/resource.go
+++ b/internal/services/plan_template/resource.go
@@ -113,7 +113,6 @@ func (r *PlanTemplateResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.PlanTemplateUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/pricing/resource.go
+++ b/internal/services/pricing/resource.go
@@ -113,7 +113,6 @@ func (r *PricingResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.PricingUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/product/resource.go
+++ b/internal/services/product/resource.go
@@ -113,7 +113,6 @@ func (r *ProductResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.ProductUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/resource_group/resource.go
+++ b/internal/services/resource_group/resource.go
@@ -114,7 +114,6 @@ func (r *ResourceGroupResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.ResourceGroupUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/scheduled_event_configuration/resource.go
+++ b/internal/services/scheduled_event_configuration/resource.go
@@ -113,7 +113,6 @@ func (r *ScheduledEventConfigurationResource) Update(ctx context.Context, req re
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.ScheduledEventConfigurationUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/transaction_type/resource.go
+++ b/internal/services/transaction_type/resource.go
@@ -113,7 +113,6 @@ func (r *TransactionTypeResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.TransactionTypeUpdateParams{}
 
 	if !data.OrgID.IsNull() {

--- a/internal/services/webhook/resource.go
+++ b/internal/services/webhook/resource.go
@@ -110,7 +110,6 @@ func (r *WebhookResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	data.Version = state.Version
 	params := m3ter.WebhookUpdateParams{}
 
 	if !data.OrgID.IsNull() {


### PR DESCRIPTION
Reverts m3ter-com/terraform-provider-m3ter#55

This fix is no longer needed as we can now use `x-stainless-terraform-always-send`.