### PR TITLE
IN-2023 Update examples for singleton resources

### DIFF
--- a/examples/resources/m3ter_custom_field/resource.tf
+++ b/examples/resources/m3ter_custom_field/resource.tf
@@ -31,3 +31,9 @@ resource "m3ter_custom_field" "example_custom_field" {
     foo = "string"
   }
 }
+
+#Singleton resources must be imported
+import {
+  to = m3ter_custom_field.example_custom_field
+  id = "orgId"
+}

--- a/examples/resources/m3ter_organization_config/resource.tf
+++ b/examples/resources/m3ter_organization_config/resource.tf
@@ -27,3 +27,9 @@ resource "m3ter_organization_config" "example_organization_config" {
   standing_charge_bill_in_advance = true
   suppressed_empty_bills = true
 }
+
+#Singleton resources must be imported
+import {
+  to = m3ter_organization_config.example_organization_config
+  id = "orgId"
+}


### PR DESCRIPTION
Add an `import` block to the examples for singleton resources - they must be imported before they can be used. 